### PR TITLE
Increased login timeout tenfold

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,9 @@ This plugin is enabled by default.
 
 ResourceLocation: `simplelogin:timeout`
 
-This plugin will kick players who haven't log in after a specific time (defined in Simple Login's
-configuration, default is 60 seconds).
+This plugin will kick players who haven't authenticated after a while (default is 600 seconds, can be changed in Simple Login's
+configuration in `<server>/<world>/serverconfig/simplelogin-server.toml`).
+The timeout value used to be 60 seconds but has been increased to 600 seconds after issues with large modpacks causing the synchronization upon login to take longer than a minute.
 
 This plugin is enabled by default.
 
@@ -174,8 +175,9 @@ All commands have auto-complete support.
 ### Server Configuration
 
 - secs: Integer
-    - Player login time limit.
-    - Default 60 seconds.
+    - Time to wait for player to authenticate, if no successful authentication happened after this long the player will be disconnected.
+    - Default 600 seconds.
+    - Used to be 60 seconds but was increased to 10 minutes because of timeout issues with large modpacks.
 
 - plugins: String Array
     - plugins to load by default.

--- a/src/main/java/top/seraphjack/simplelogin/SLConfig.java
+++ b/src/main/java/top/seraphjack/simplelogin/SLConfig.java
@@ -24,7 +24,7 @@ public final class SLConfig {
 
             secs = builder
                     .comment("Login Timeout(s)")
-                    .defineInRange("secs", 60, 0, 1200);
+                    .defineInRange("secs", 600, 0, 1200);
 
             whitelistCommands = builder
                     .comment("Commands in whitelist can be executed before player login.")


### PR DESCRIPTION
Fixes issue detailed in my comment at https://github.com/TheRandomLabs/RandomPatches/issues/141#issuecomment-844342890

Large modpacks can come hand-in-hand with client-side freezes lasting over a minute, causing a disconnect even if the login credentials match.
Large modpacks feature mods like RandomPatches to increase the timeouts used by minecraft and forge for this reason, and despite having this mod it seemed like https://github.com/TheRandomLabs/RandomPatches/issues/141 was happening on our server as well, until i found this timeout value that exactly matches how long it takes for a player to time out on our server.
Increasing this value tenfold in `<server>/<world>/serverconfig/simplelogin-server.toml` fixed this issue for the server i am one of the operators of.
Since players should not be able to do any damage while not logged in this should not have any negative effects.